### PR TITLE
Uses mozillaAttributeReference variable instead of duplicate string

### DIFF
--- a/cmd/gen/html_attrs.go
+++ b/cmd/gen/html_attrs.go
@@ -18,7 +18,7 @@ import (
 const mozAttributeReference = "https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes"
 
 func downloadAttrs(dest string) error {
-	res, err := http.Get("https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes")
+	res, err := http.Get(mozAttributeReference)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Explanation: This changeset involves utilizing an existing constant `mozillaAttributeReference` (that has the value `"https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes"`) instead of a duplicate string of the same value.